### PR TITLE
fix: make gradientWrapper fill parent

### DIFF
--- a/src/Shimmer.tsx
+++ b/src/Shimmer.tsx
@@ -56,10 +56,5 @@ const styles = StyleSheet.create({
     height: '100%',
     width: '100%',
   },
-  gradientWrapper: {
-    overflow: 'hidden',
-    position: 'relative',
-    width: 100,
-    height: 100,
-  },
+  gradientWrapper: StyleSheet.absoluteFillObject,
 });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR updates the [Shimmer](cci:1://file:///Users/alex.zamfir/Documents/callstack/react-native-fast-shimmer/src/Shimmer.tsx:10:0-49:2) component's internal `gradientWrapper` to use `StyleSheet.absoluteFillObject`.

Previously, the animated gradient had a fixed internal width of 100px. This change makes the gradient dynamically fill the entire area of the [Shimmer](cci:1://file:///Users/alex.zamfir/Documents/callstack/react-native-fast-shimmer/src/Shimmer.tsx:10:0-49:2) component, providing a more intuitive full-area shimmer effect by default. Gradient customization props (`linearGradients`, `gradientStart`, `gradientEnd`) will now apply relative to the component's full dimensions.

### Test plan

1.  Render a [Shimmer](cci:1://file:///Users/alex.zamfir/Documents/callstack/react-native-fast-shimmer/src/Shimmer.tsx:10:0-49:2) component.
    *   **Expected:** The shimmer animation now covers the entire component area, not just a 100px wide band.
2.  Render a [Shimmer](cci:1://file:///Users/alex.zamfir/Documents/callstack/react-native-fast-shimmer/src/Shimmer.tsx:10:0-49:2) component wider than 100px with custom `linearGradients`.
    *   **Expected:** The custom gradient colors now span the full width of the component.