### PR TITLE
Update linearGradients default color in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ export default function App() {
 | Prop              | Type                          | Default                                       | Description                                             |
 | ----------------- | ----------------------------- | --------------------------------------------- | ------------------------------------------------------- |
 | `style`           | `ViewStyle` or `ViewStyle[]`  | `undefined`                                   | Custom styles for the Shimmer container.                |
-| `linearGradients` | `string[]`                    | `['transparent', '#FFFFFF30', 'transparent']` | Array of colors for the linear gradient animation.      |
+| `linearGradients` | `string[]`                    | `['transparent', '#FFFFFFFF', 'transparent']` | Array of colors for the linear gradient animation.      |
 | `easing`          | `EasingFunction` (reanimated) | `Easing.linear`                               | Easing for shimmer time interpolation                   |
 | `speed`           | `number`                      | `1`                                           | Speed param for multiplying speed of individual shimmer |
 | `gradientStart`   | `{ x: number; y: number }`    | `{ x: 0, y: 0.5 }`                            | Start coordinates for the linear gradient.              |


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

README default value was wrong.

I was confused AF cause I was using explicitly using the default value and got a different look from omitting the prop, found out internally that the value is different


### Test plan

docs change
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
